### PR TITLE
Feat: 상품 명령 API 추가 및 변경

### DIFF
--- a/service/product/src/main/java/org/icd4/commerce/adapter/webapi/ProductApi.java
+++ b/service/product/src/main/java/org/icd4/commerce/adapter/webapi/ProductApi.java
@@ -7,8 +7,7 @@ import org.icd4.commerce.adapter.webapi.dto.ProductResponse;
 import org.icd4.commerce.adapter.webapi.dto.ProductVariantResponse;
 import org.icd4.commerce.application.command.ProductCommandService;
 import org.icd4.commerce.application.query.ProductQueryService;
-import org.icd4.commerce.domain.product.request.ProductCategoryUpdateRequest;
-import org.icd4.commerce.domain.product.request.ProductCreateRequest;
+import org.icd4.commerce.domain.product.request.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -45,15 +44,46 @@ public class ProductApi {
         return ResponseEntity.ok(productQueryService.findVariantBySku(skuId));
     }
 
-    @PatchMapping("/{productId}/category")
-    public ResponseEntity<ProductResponse> changeCategory(
-            @PathVariable String productId,
-            @Valid @RequestBody ProductCategoryUpdateRequest request) {
-        return ResponseEntity.ok(productCommandService.changeCategory(productId, request));
-    }
-
     @PostMapping
     public ResponseEntity<ProductResponse> create(@RequestBody ProductCreateRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(productCommandService.create(request));
     }
+
+    @PatchMapping("/{productId}/category")
+    public ResponseEntity<ProductResponse> changeCategory(
+            @PathVariable String productId,
+            @RequestHeader("X-Seller-Id") String sellerId,
+            @Valid @RequestBody ProductCategoryUpdateRequest request) {
+        return ResponseEntity.ok(productCommandService.changeCategory(productId, sellerId, request));
+    }
+
+    @PatchMapping("{productId}/price")
+    public ResponseEntity<ProductResponse> changePrice(
+            @PathVariable String productId,
+            @RequestHeader("X-Seller-Id") String sellerId,
+            @Valid @RequestBody ProductPriceUpdateRequest request) {
+        return ResponseEntity.ok(productCommandService.changeProductPrice(productId, sellerId, request));
+    }
+
+    @PatchMapping("{productId}/activate")
+    public ResponseEntity<ProductResponse> activate(
+            @PathVariable String productId,
+            @RequestHeader("X-Seller-Id") String sellerId) {
+        return ResponseEntity.ok(productCommandService.activate(productId, sellerId));
+    }
+
+    @PatchMapping("{productId}/inactivate")
+    public ResponseEntity<ProductResponse> inactivate(
+            @PathVariable String productId,
+            @RequestHeader("X-Seller-Id") String sellerId) {
+        return ResponseEntity.ok(productCommandService.inactivate(productId, sellerId));
+    }
+
+    @DeleteMapping("{productId}")
+    public ResponseEntity<ProductResponse> delete(
+            @PathVariable String productId,
+            @RequestHeader("X-Seller-Id") String sellerId) {
+        return ResponseEntity.ok(productCommandService.deleteProduct(productId, sellerId));
+    }
+
 }

--- a/service/product/src/main/java/org/icd4/commerce/application/command/ProductCommandService.java
+++ b/service/product/src/main/java/org/icd4/commerce/application/command/ProductCommandService.java
@@ -4,9 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.icd4.commerce.adapter.webapi.dto.ProductResponse;
 import org.icd4.commerce.adapter.webapi.dto.event.ProductCreatedEventPayload;
 import org.icd4.commerce.domain.product.model.Product;
-import org.icd4.commerce.domain.product.model.ProductMoney;
-import org.icd4.commerce.domain.product.request.ProductCategoryUpdateRequest;
-import org.icd4.commerce.domain.product.request.ProductCreateRequest;
+import org.icd4.commerce.domain.product.request.*;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
@@ -28,14 +26,14 @@ public class ProductCommandService {
         return ProductResponse.fromDomain(productRegisterService.create(request));
     }
 
-    public ProductResponse changeCategory(String productId, ProductCategoryUpdateRequest request) {
+    public ProductResponse changeCategory(String productId, String sellerId, ProductCategoryUpdateRequest request) {
         return ProductResponse.fromDomain(
-                productModifierService.changeCategory(productId, request.categoryId(), request.sellerId())
+                productModifierService.changeCategory(productId, sellerId, request.categoryId())
         );
     }
     //TODO 초희님 구현
-    public ProductResponse changeProductPrice(String productId, String sellerId, ProductMoney newPrice) {
-        return ProductResponse.fromDomain(productModifierService.changeProductPrice(productId, sellerId, newPrice));
+    public ProductResponse changeProductPrice(String productId, String sellerId, ProductPriceUpdateRequest request) {
+        return ProductResponse.fromDomain(productModifierService.changeProductPrice(productId, sellerId, request.price()));
     }
     //TODO 초희님 구현
     public ProductResponse activate(String productId, String sellerId) {

--- a/service/product/src/main/java/org/icd4/commerce/application/command/ProductModifierService.java
+++ b/service/product/src/main/java/org/icd4/commerce/application/command/ProductModifierService.java
@@ -17,7 +17,7 @@ public class ProductModifierService implements ProductModifier {
 
     @Override
     @Transactional
-    public Product changeCategory(String productId, String categoryId, String sellerId) {
+    public Product changeCategory(String productId, String sellerId, String categoryId) {
         Product product = productFinder.findByIdAndSellerId(productId,sellerId);
         product.changeCategory(categoryId);
         return productRepository.save(product);

--- a/service/product/src/main/java/org/icd4/commerce/domain/product/request/ProductCategoryUpdateRequest.java
+++ b/service/product/src/main/java/org/icd4/commerce/domain/product/request/ProductCategoryUpdateRequest.java
@@ -4,7 +4,6 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record ProductCategoryUpdateRequest(
-        @NotBlank @NotNull String categoryId,
-        @NotBlank @NotNull String sellerId
+        @NotBlank @NotNull String categoryId
 ) {
 }


### PR DESCRIPTION
## Feat: 상품 명령 API 추가 및 변경

### 개요
상품 도메인에 대한 **명령(Command) API**들을 추가하고 기존 API를 개선했습니다. 이번 변경의 핵심은 상품의 **가격 변경, 활성화/비활성화, 삭제** 기능을 위한 엔드포인트를 구현하고, 모든 `command`성 API에서 **판매자 ID(Seller ID)**를 **`X-Seller-Id` HTTP 헤더**를 통해 일관성 있게 처리하도록 리팩토링한 것입니다. 또한, 요청 본문(RequestBody)을 통한 데이터 유효성 검증 로직을 강화하여 API의 견고성을 높였습니다.

### 주요 변경 사항

1.  **상품 가격 변경 API (`PATCH /api/v1/product/{productId}/price`) 추가:**
    * 특정 상품의 가격을 변경하는 API를 구현했습니다.
    * `ProductPriceUpdateRequest` DTO를 사용하여 `price` (ProductMoney 값 객체)를 요청 본문으로 받습니다.
    * `@Valid` 및 `@NotNull` 어노테이션을 활용하여 DTO 및 내포된 값 객체(`ProductMoney`)의 유효성을 검증합니다.

2.  **상품 활성화/비활성화 API (`PATCH /api/v1/product/{productId}/activate`, `PATCH /api/v1/product/{productId}/inactivate`) 추가:**
    * 상품의 상태를 활성화/비활성화하는 API를 각각 추가했습니다.

3.  **상품 삭제 API (`DELETE /api/v1/product/{productId}`) 추가:**
    * 특정 상품을 논리적으로 삭제(isDeleted 플래그 업데이트)하는 API를 구현했습니다. `DELETE` 메서드를 사용하여 자원의 제거 의도를 명확히 표현했습니다.

4.  **판매자 ID (`sellerId`) 처리 방식 통일:**
    * 기존 카테고리 변경 API를 포함하여, 모든 명령 API에서 `sellerId`를 `@RequestHeader("X-Seller-Id")`로 받도록 통일했습니다.
    * 이는 `sellerId`가 자원의 속성이라기보다는 **요청을 보낸 주체(Context)**에 대한 정보이며, 향후 인증/인가 시스템 도입 시 유연성을 확보하기 위한 설계 결정입니다.


### 고려 사항

* 현재 `sellerId`는 요청의 맥락 파악 및 로깅을 위해 사용되며, **본 PR에는 인증/인가 로직이 포함되어 있지 않습니다.** 따라서 `sellerId`는 현재 신뢰할 수 있는 식별자로 사용될 수 없으므로, 향후 보안 강화를 위한 **인증/인가 시스템 도입이 필수적**입니다.
* 논리적 삭제는 `DELETE` 메서드의 명확한 의도를 따르되, 내부적으로는 `isDeleted` 플래그를 업데이트하여 데이터를 보존하는 방식으로 구현되었습니다.
* API 디자인의 일관성을 위해, 향후 다른 `command`성 API 추가 시에도 판매자 ID는 헤더로 처리하고, 요청 본문은 적절한 DTO와 유효성 검증을 함께 적용하는 패턴을 유지할 예정입니다.

